### PR TITLE
Consolidated Entity Framework Core Design Package to fix error

### DIFF
--- a/src/DwitTech.AccountService.WebApi/DwitTech.AccountService.WebApi.csproj
+++ b/src/DwitTech.AccountService.WebApi/DwitTech.AccountService.WebApi.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Found a bug in a previous commit, which has already been merged with the master branch, and was preventing the account service from running. There was a conflict between two different Entity Framework Core Relational versions(6.0.12 & 6.0.13) installed in Data and Web Api projects. By Updating the Entity Framework Design Package, the bug was fixed.